### PR TITLE
Add GitHub secrets and update .gitignore

### DIFF
--- a/.github/workflows/set-secrets.yml
+++ b/.github/workflows/set-secrets.yml
@@ -1,0 +1,18 @@
+name: Set Secrets
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  set-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set ORCID secrets
+        run: |
+          echo "ORCID_CLIENT_ID=${{ secrets.ORCID_CLIENT_ID }}"
+          echo "ORCID_CLIENT_SECRET=${{ secrets.ORCID_CLIENT_SECRET }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Yibei Chen - Academic Portfolio
+
+## Setting Up GitHub Secrets
+
+To securely store and manage sensitive information such as API keys and access tokens, you can use GitHub Secrets. Follow the steps below to set up GitHub Secrets for this repository:
+
+1. **Navigate to the repository on GitHub:**
+   Go to the main page of the repository on GitHub.
+
+2. **Go to the Settings tab:**
+   Click on the "Settings" tab at the top of the repository page.
+
+3. **Access Secrets:**
+   In the left sidebar, click on "Secrets and variables" and then select "Actions".
+
+4. **Add a new secret:**
+   Click on the "New repository secret" button.
+
+5. **Create secrets for ORCID API:**
+   Add the following secrets:
+   - `ORCID_CLIENT_ID`: Your ORCID client ID.
+   - `ORCID_CLIENT_SECRET`: Your ORCID client secret.
+
+6. **Save the secrets:**
+   Click the "Add secret" button to save each secret.
+
+Once the secrets are added, they can be accessed in your GitHub Actions workflows using the `secrets` context.
+
+## Example GitHub Actions Workflow
+
+Here is an example of a GitHub Actions workflow file (`.github/workflows/set-secrets.yml`) that sets up the `ORCID_CLIENT_ID` and `ORCID_CLIENT_SECRET` secrets:
+
+```yaml
+name: Set Secrets
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  set-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set ORCID secrets
+        run: |
+          echo "ORCID_CLIENT_ID=${{ secrets.ORCID_CLIENT_ID }}"
+          echo "ORCID_CLIENT_SECRET=${{ secrets.ORCID_CLIENT_SECRET }}"
+```
+
+This workflow will run whenever there is a push to the `main` branch and will set the ORCID secrets for use in your scripts.

--- a/scripts/fetchPublications.js
+++ b/scripts/fetchPublications.js
@@ -7,14 +7,14 @@ import dotenv from 'dotenv';
 // Load environment variables from .env file
 dotenv.config();
 
-// Configuration from environment variables
+// Configuration from environment variables or GitHub secrets
 const ORCID_ID = process.env.ORCID_ID || '0000-0003-2882-0900';
-const CLIENT_ID = process.env.ORCID_CLIENT_ID;
-const CLIENT_SECRET = process.env.ORCID_CLIENT_SECRET;
+const CLIENT_ID = process.env.ORCID_CLIENT_ID || process.env.GITHUB_ORCID_CLIENT_ID;
+const CLIENT_SECRET = process.env.ORCID_CLIENT_SECRET || process.env.GITHUB_ORCID_CLIENT_SECRET;
 
-// Validate required environment variables
+// Validate required environment variables or GitHub secrets
 if (!CLIENT_ID || !CLIENT_SECRET) {
-  console.error('Error: ORCID_CLIENT_ID and ORCID_CLIENT_SECRET must be set in .env file');
+  console.error('Error: ORCID_CLIENT_ID and ORCID_CLIENT_SECRET must be set in .env file or as GitHub secrets');
   process.exit(1);
 }
 


### PR DESCRIPTION
Add GitHub Actions workflow and update scripts to use GitHub secrets.

* **GitHub Actions Workflow**: Add `.github/workflows/set-secrets.yml` to set up `ORCID_CLIENT_ID` and `ORCID_CLIENT_SECRET` secrets.
* **Script Update**: Modify `scripts/fetchPublications.js` to use GitHub secrets with a fallback to `.env` file.
* **Documentation**: Add instructions in `README.md` for setting up GitHub secrets.
* **Gitignore**: Add `.env` and `.DS_Store` to `.gitignore`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yibeichan/yibeichan.github.io/pull/1?shareId=0201f3c8-e69f-43f8-84c3-da9d60f52b41).