### PR TITLE
Fix homepage scrolling issue on web

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-gray-900 text-white absolute bottom-0 w-full">
+    <footer className="bg-gray-900 text-white absolute bottom-0 w-full p-4">
       <div className="max-w-7xl mx-auto py-6 px-4 overflow-hidden sm:px-6 lg:px-8">    
         <p className="text-center text-base text-gray-400">
           &copy; {currentYear} Yibei Chen. All rights reserved. Created with{' '}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-gray-900 text-white">
+    <footer className="bg-gray-900 text-white absolute bottom-0 w-full">
       <div className="max-w-7xl mx-auto py-6 px-4 overflow-hidden sm:px-6 lg:px-8">    
         <p className="text-center text-base text-gray-400">
           &copy; {currentYear} Yibei Chen. All rights reserved. Created with{' '}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -4,7 +4,7 @@ import { socialLinks } from '../data/socialLinks';
 function Home() {
   return (
     <div className="h-[100vh] flex flex-col justify-between p-4 sm:px-4 home-page">
-      <div className="max-w-6xl mx-auto w-full flex-grow">
+      <div className="max-w-6xl mx-auto w-full flex-grow p-4">
         <div className="flex flex-col md:flex-row gap-6 md:gap-8">
           {/* Left Column */}
           <div className="w-full md:w-1/4 lg:w-1/5 flex flex-col items-center md:items-stretch">

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,8 +3,8 @@ import { socialLinks } from '../data/socialLinks';
 
 function Home() {
   return (
-    <div className="min-h-[calc(100vh-theme(spacing.32))] flex items-center justify-center p-4 sm:px-4">
-      <div className="max-w-6xl mx-auto w-full">
+    <div className="h-[100vh] flex flex-col justify-between p-4 sm:px-4 home-page">
+      <div className="max-w-6xl mx-auto w-full flex-grow">
         <div className="flex flex-col md:flex-row gap-6 md:gap-8">
           {/* Left Column */}
           <div className="w-full md:w-1/4 lg:w-1/5 flex flex-col items-center md:items-stretch">

--- a/src/index.css
+++ b/src/index.css
@@ -56,4 +56,5 @@ a, button {
 .home-page {
   height: 100vh;
   overflow: hidden;
+  padding: 16px; /* Ensure equal padding on all sides */
 }

--- a/src/index.css
+++ b/src/index.css
@@ -51,3 +51,9 @@ a, button {
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
+
+/* Enforce no-scroll policy for the home page on web */
+.home-page {
+  height: 100vh;
+  overflow: hidden;
+}


### PR DESCRIPTION
Update the home page to prevent scrolling on web.

* **Home Component**: Set the height of the main container to `100vh` and adjust the padding and margin to ensure the content fits within the viewport.
* **Footer Component**: Position the footer absolutely at the bottom of the page.
* **CSS**: Add CSS rule to enforce no-scroll policy for the home page on web.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yibeichan/yibeichan.github.io/pull/9?shareId=15e1a4a4-ba30-4e2e-8413-4842e01be667).