### PR TITLE
Reduce banner height and make pages more compact

### DIFF
--- a/src/components/Research.jsx
+++ b/src/components/Research.jsx
@@ -5,9 +5,9 @@ function Research() {
   return (
     <div>
       {/* Hero Section - background will be full width */}
-      <div className="bg-gray-900 text-white py-24">
+      <div className="bg-gray-900 text-white py-12">
         {/* This inner div constrains the text content to align with navbar */}
-        <div className="max-w-6xl mx-auto px-4">
+        <div className="max-w-6xl mx-auto px-2">
           <div> {/* This div previously held max-w-3xl, then was plain. It now inherits parent's constraint for text. */}
             <h1 className="text-4xl font-bold tracking-tight sm:text-5xl font-serif mb-6">
               Research Highlights
@@ -20,11 +20,11 @@ function Research() {
       </div>
 
       {/* Research Areas - wrapped to align its content */}
-      <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="max-w-6xl mx-auto px-2 py-4">
         <div className="space-y-12">
           {researchAreas.map((area) => (
             <div key={area.id} className="bg-white rounded-lg shadow-lg overflow-hidden">
-              <div className="p-6">
+              <div className="p-4">
                 <h3 className="text-2xl font-semibold text-gray-800 mb-4 font-serif">{area.title}</h3>
                 <p className="text-gray-600 mb-8 leading-relaxed">{area.description}</p>
                 
@@ -36,7 +36,7 @@ function Research() {
                         alt={project.title}
                         className="w-full h-64 object-cover"
                       />
-                      <div className="p-6">
+                      <div className="p-4">
                         {project.tags && (
                           <div className="flex flex-wrap gap-2 mb-4">
                             {project.tags.map((tag, tagIndex) => (

--- a/src/components/Software.jsx
+++ b/src/components/Software.jsx
@@ -18,8 +18,8 @@ function Section({ children, background = 'white', isFirst = false, customPaddin
 function Software() {
   return (
     <div>
-      <div className="bg-gray-800 text-white py-24">
-        <div className="max-w-6xl mx-auto px-4">
+      <div className="bg-gray-800 text-white py-12">
+        <div className="max-w-6xl mx-auto px-2">
           <div>
             <h1 className="text-4xl font-bold tracking-tight sm:text-5xl font-serif mb-6">
               Open Source Projects
@@ -31,7 +31,7 @@ function Software() {
         </div>
       </div>
 
-      <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="max-w-6xl mx-auto px-2 py-4">
         <Section isFirst={true}>
           <div className="space-y-16">
             {softwareProjects.map((project, index) => (

--- a/src/index.css
+++ b/src/index.css
@@ -57,3 +57,9 @@ a, button {
   height: 100vh;
   overflow: hidden;
 }
+
+/* Global styles to reduce margin and padding */
+* {
+  margin: 0.5rem;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
Reduce the height of the banner on the research and software pages and make all pages more compact by reducing margin and padding.

* Change the banner height in `src/components/Research.jsx` from `py-24` to `py-12`.
* Adjust the margin and padding in `src/components/Research.jsx` by changing `px-4` to `px-2` and `py-8` to `py-4`.
* Change the banner height in `src/components/Software.jsx` from `py-24` to `py-12`.
* Adjust the margin and padding in `src/components/Software.jsx` by changing `px-4` to `px-2` and `py-8` to `py-4`.
* Add global styles in `src/index.css` to reduce margin and padding for all elements to `0.5rem`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yibeichan/yibeichan.github.io/pull/10?shareId=2f14c4ac-aeaf-4f6b-af95-aa25d9db556c).